### PR TITLE
Remove system menu and add quit button

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -294,12 +294,7 @@ function createTray() {
     }
     tray = new Tray(image);
     updateTrayTitleAndIcon();
-    const contextMenu = Menu.buildFromTemplate([
-        { label: 'Open Balance', click: toggleWindow },
-        { type: 'separator' },
-        { label: 'Quit', role: 'quit' }
-    ]);
-    tray.setContextMenu(contextMenu);
+    // Remove context menu to hide system menu - only handle click events
     tray.on('click', toggleWindow);
 }
 
@@ -487,6 +482,10 @@ ipcMain.handle('balance:open-data-folder', () => {
     } catch (e) {
         console.error('Failed to open data folder:', e);
     }
+});
+
+ipcMain.handle('balance:quit', () => {
+    app.quit();
 });
 
 app.whenReady().then(() => {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -10,6 +10,7 @@ contextBridge.exposeInMainWorld('balance', {
     saveSettings: (settings) => ipcRenderer.invoke('balance:save-settings', settings),
     open: () => ipcRenderer.invoke('balance:open'),
     openDataFolder: () => ipcRenderer.invoke('balance:open-data-folder'),
+    quit: () => ipcRenderer.invoke('balance:quit'),
     onState: (callback) => {
         const handler = (_event, message) => callback(message);
         ipcRenderer.on('balance:state', handler);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -71,6 +71,9 @@
     function openDataFolder() {
         api.openDataFolder();
     }
+    function quit() {
+        api.quit();
+    }
 
     $: pinkHasMore = computed?.outOfBalanceSign >= 0;
     $: withinRange = computed?.withinRange;
@@ -98,6 +101,7 @@
 >
     <div class="row">
         <div class="title">Balance</div>
+        <div class="btn" title="Quit" on:click={quit}>❌</div>
         <div class="btn" title="Options (o)" on:click={openOptions}>⚙️</div>
     </div>
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -101,7 +101,6 @@
 >
     <div class="row">
         <div class="title">Balance</div>
-        <div class="btn" title="Quit" on:click={quit}>❌</div>
         <div class="btn" title="Options (o)" on:click={openOptions}>⚙️</div>
     </div>
 
@@ -266,6 +265,13 @@
                         style="background:#ffd2d2"
                     >
                         Cancel
+                    </div>
+                    <div
+                        class="btn"
+                        on:click={quit}
+                        style="background:#ffcccb"
+                    >
+                        Quit App
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Hide the macOS system menu on tray icon click and add an in-app quit button.

On macOS, setting a context menu on a tray icon causes both the app window and the system-styled menu to appear when clicked. Removing the context menu resolves this, and an in-app quit button maintains quit functionality.

---
Linear Issue: [BAL-7](https://linear.app/balance-jonah/issue/BAL-7/when-you-click-the-menu-bar-icon-right-now-it-shows-the-app)

<a href="https://cursor.com/background-agent?bcId=bc-e32c3acc-d2c8-4a44-97eb-e2434b0af9f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e32c3acc-d2c8-4a44-97eb-e2434b0af9f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

