### PR TITLE
Round hours instead of flooring or ceiling

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -102,7 +102,7 @@ function getOutOfBalanceHoursAbs() {
     const totalMinutes0 = getTotalMinutesForMission(0);
     const totalMinutes1 = getTotalMinutesForMission(1);
     const diffMinutes = Math.abs(totalMinutes0 - totalMinutes1);
-    return Math.floor(diffMinutes / 60);
+    return Math.round(diffMinutes / 60);
 }
 
 function getOutOfBalanceSign() {
@@ -123,7 +123,7 @@ function updateTrayTitleAndIcon() {
     renderTrayImage(balanceNum, minutesLeft, () => { });
     // Only show the minutes as system text; colored balance + pie are in the image
     try { tray.setTitle(`${minutesLeft}`); } catch { }
-    tray.setToolTip(`${settings.missions[0].name}: ${Math.floor(getTotalMinutesForMission(0) / 60)}h | ${settings.missions[1].name}: ${Math.floor(getTotalMinutesForMission(1) / 60)}h`);
+    tray.setToolTip(`${settings.missions[0].name}: ${Math.round(getTotalMinutesForMission(0) / 60)}h | ${settings.missions[1].name}: ${Math.round(getTotalMinutesForMission(1) / 60)}h`);
 }
 
 function timeRemainingSeconds() {


### PR DESCRIPTION
Replace `Math.floor` with `Math.round` for hour calculations to ensure accurate rounding of "hours out of balance" and mission hours in the tooltip.

The previous implementation truncated fractional hours, causing values like 1.5 hours to display as 1 hour. This change ensures that values are rounded to the nearest whole hour, providing a more intuitive and correct representation.

---
Linear Issue: [BAL-16](https://linear.app/balance-jonah/issue/BAL-16/the-of-hours-out-of-balance-should-not-be-floored-or-ceiled-appears-to)

<a href="https://cursor.com/background-agent?bcId=bc-887c7055-6a75-4c0e-a604-e1744ff73afc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-887c7055-6a75-4c0e-a604-e1744ff73afc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

