### PR TITLE
Update time display to lifetime format

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -399,7 +399,7 @@ function getPublicState() {
             outOfBalanceHours: getOutOfBalanceHoursAbs(),
             outOfBalanceSign: getOutOfBalanceSign(),
             withinRange: isWithinAcceptableRange(),
-            todayMinutes: getTodayMinutesForCurrentMission()
+            lifetimeMinutes: getTotalMinutesForMission(state.currentMissionIndex)
         }
     };
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -126,7 +126,7 @@
                 class="pill"
                 style="color: {settings.missions[state.currentMissionIndex].color}"
             >
-                Today: <strong>{computed.todayMinutes || 0}</strong> minutes
+                Lifetime: <strong>{Math.floor((computed.lifetimeMinutes || 0) / 60)}h{(computed.lifetimeMinutes || 0) % 60}m</strong>
             </div>
         </div>
 


### PR DESCRIPTION
Update time display from "Today: x minutes" to "Lifetime: xhym" to show total accumulated time for a mission.

---
Linear Issue: [BAL-17](https://linear.app/balance-jonah/issue/BAL-17/instead-of-today-x-minutes-show-lifetime-xhym-x-hours-y-minutes)

<a href="https://cursor.com/background-agent?bcId=bc-2f5239c6-ecd0-4562-8d6a-c90d68290cb1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f5239c6-ecd0-4562-8d6a-c90d68290cb1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

