### PR TITLE
Ensure break countdown text is gray

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -160,7 +160,7 @@
 
         <div
             class="timer"
-            style="color:{settings.missions[state.currentMissionIndex].color}"
+            style="color:{state.timer?.isBreak ? crayon.gray : settings.missions[state.currentMissionIndex].color}"
         >
             {String(
                 Math.floor((state.timer?.remainingSeconds || 0) / 60),


### PR DESCRIPTION
Make break timer text gray to indicate untracked time.

---
Linear Issue: [BAL-36](https://linear.app/balance-jonah/issue/BAL-36/when-counting-down-from-a-break-the-text-should-always-be-gray-as-it)

<a href="https://cursor.com/background-agent?bcId=bc-551d178d-12d3-4d45-9941-09535a653a99">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-551d178d-12d3-4d45-9941-09535a653a99">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

