### PR TITLE
Fix keyboard shortcut conflict in text box

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -91,7 +91,15 @@
 
 <svelte:window
     on:keydown={(e) => {
-        if (e.key.toLowerCase() === "o") openOptions();
+        const target = e.target;
+        const tag = (target?.tagName || "").toLowerCase();
+        const isEditable =
+            tag === "input" ||
+            tag === "textarea" ||
+            tag === "select" ||
+            target?.isContentEditable;
+        if (isEditable || showOptions || e.metaKey || e.ctrlKey || e.altKey) return;
+        if (e.key && e.key.toLowerCase() === "o" && !e.repeat) openOptions();
     }}
 />
 


### PR DESCRIPTION
Prevent the global 'o' keyboard shortcut from triggering when typing in editable fields, fixing a bug where it would incorrectly open the options modal.

---
Linear Issue: [BAL-39](https://linear.app/balance-jonah/issue/BAL-39/bug-when-you-press-o-on-the-settings-even-if-youre-in-a-text-box-it)

<a href="https://cursor.com/background-agent?bcId=bc-0f901225-0238-46c2-9b1b-5d921842fc86">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0f901225-0238-46c2-9b1b-5d921842fc86">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

