### PR TITLE
Implement manual time add/remove

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -204,6 +204,25 @@ function incrementDailyMinute() {
     notifyRenderer('state');
 }
 
+// Adjust today's tracked minutes for the current mission by a delta (can be negative)
+function adjustTodayMinutesForCurrentMission(deltaMinutes) {
+    const delta = Math.round(deltaMinutes);
+    if (!delta) return;
+
+    const today = getTodayDateString();
+    const missionKey = `mission_${state.currentMissionIndex}`;
+
+    if (!state.dailyMinutes) state.dailyMinutes = {};
+    if (!state.dailyMinutes[missionKey]) state.dailyMinutes[missionKey] = {};
+    const current = state.dailyMinutes[missionKey][today] || 0;
+    const next = Math.max(0, current + delta);
+    state.dailyMinutes[missionKey][today] = next;
+
+    saveData();
+    notifyRenderer('state');
+    updateTrayTitleAndIcon();
+}
+
 function startMinuteTracking() {
     if (minuteTrackingInterval) clearTimeout(minuteTrackingInterval);
 
@@ -611,6 +630,7 @@ ipcMain.handle('balance:stop', () => { stopTimer(); return getPublicState(); });
 ipcMain.handle('balance:pause', () => { pauseTimer(); return getPublicState(); });
 ipcMain.handle('balance:resume', () => { resumeTimer(); return getPublicState(); });
 ipcMain.handle('balance:extend', (_e, seconds) => { extendTimer(seconds); return getPublicState(); });
+ipcMain.handle('balance:adjust-minutes', (_e, minutesDelta) => { adjustTodayMinutesForCurrentMission(minutesDelta); return getPublicState(); });
 ipcMain.handle('balance:switch-mission', (_e, idx) => { state.currentMissionIndex = Math.max(0, Math.min(2, idx)); notifyRenderer('state'); updateTrayTitleAndIcon(); return getPublicState(); });
 ipcMain.handle('balance:save-settings', (_e, nextSettings) => {
     const prevDir = getUserDir();

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -8,6 +8,7 @@ contextBridge.exposeInMainWorld('balance', {
     pause: () => ipcRenderer.invoke('balance:pause'),
     resume: () => ipcRenderer.invoke('balance:resume'),
     extend: (seconds) => ipcRenderer.invoke('balance:extend', seconds),
+    adjustMinutes: (minutesDelta) => ipcRenderer.invoke('balance:adjust-minutes', minutesDelta),
     switchMission: (index) => ipcRenderer.invoke('balance:switch-mission', index),
     saveSettings: (settings) => ipcRenderer.invoke('balance:save-settings', settings),
     open: () => ipcRenderer.invoke('balance:open'),

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -73,6 +73,13 @@
         api.switchMission(i);
     }
 
+    function addTrackedMinute() {
+        api.adjustMinutes(1);
+    }
+    function removeTrackedMinute() {
+        api.adjustMinutes(-1);
+    }
+
     function openOptions() {
         editingSettings = JSON.parse(JSON.stringify(settings));
         showOptions = true;
@@ -187,6 +194,20 @@
                     title="Decrease time by 1 minute"
                 >
                     -
+                </button>
+                <button
+                    class="btn time-control-btn"
+                    on:click={addTrackedMinute}
+                    title="Add tracked minute to today"
+                >
+                    +m
+                </button>
+                <button
+                    class="btn time-control-btn"
+                    on:click={removeTrackedMinute}
+                    title="Remove tracked minute from today"
+                >
+                    -m
                 </button>
             </div>
             <div class="keyboard-instructions">


### PR DESCRIPTION
Add manual add/remove time buttons to address issue BAL-43.

---
Linear Issue: [BAL-43](https://linear.app/balance-jonah/issue/BAL-43/add-the-ability-to-addremove-time-manually)

<a href="https://cursor.com/background-agent?bcId=bc-a58c62f8-7631-433a-9915-b428379239c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a58c62f8-7631-433a-9915-b428379239c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

