### PR TITLE
Fix zoom in/out with cmd +/-

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -278,6 +278,18 @@ function createWindow() {
 
     mainWindow = new BrowserWindow(windowOptions);
 
+    // Intercept zoom shortcuts at the app level
+    mainWindow.webContents.on('before-input-event', (event, input) => {
+        const isCmdOrCtrl = input.meta || input.control;
+        if (!isCmdOrCtrl) return;
+        // Block Cmd/Ctrl + + / - / = / 0
+        const key = (input.key || '').toLowerCase();
+        if (key === '+' || key === '=' || key === '-' || key === '_'
+            || key === 'add' || key === 'subtract' || key === '0') {
+            event.preventDefault();
+        }
+    });
+
     // Wait for content to load before showing
     mainWindow.webContents.once('did-finish-load', () => {
         console.log('Window content loaded successfully');

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,4 +1,4 @@
-const { contextBridge, ipcRenderer } = require('electron');
+const { contextBridge, ipcRenderer, webFrame } = require('electron');
 
 contextBridge.exposeInMainWorld('balance', {
     getState: () => ipcRenderer.invoke('balance:get-state'),
@@ -22,5 +22,21 @@ contextBridge.exposeInMainWorld('balance', {
     },
     platform: process.platform
 });
+
+// Disable all zooming in the renderer (pinch, Cmd/Ctrl +/- , programmatic)
+try {
+    // Disallow visual zoom (pinch/gesture)
+    if (typeof webFrame.setVisualZoomLevelLimits === 'function') {
+        webFrame.setVisualZoomLevelLimits(1, 1);
+    }
+    // Disallow zoom level changes
+    if (typeof webFrame.setZoomLevelLimits === 'function') {
+        webFrame.setZoomLevelLimits(1, 1);
+    }
+    // Ensure base zoom factor is 1
+    if (typeof webFrame.setZoomFactor === 'function') {
+        webFrame.setZoomFactor(1);
+    }
+} catch {}
 
 


### PR DESCRIPTION
Disable page zoom in the Electron app to prevent accidental zooming via keyboard shortcuts and gestures.

---
Linear Issue: [BAL-47](https://linear.app/balance-jonah/issue/BAL-47/cmd-works-to-zoom-inout-of-the-page)

<a href="https://cursor.com/background-agent?bcId=bc-ad46ad5d-87b9-4920-b5fe-83117b7c78dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ad46ad5d-87b9-4920-b5fe-83117b7c78dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

