### PR TITLE
Create daily balance.json backups

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -65,6 +65,7 @@ let minuteTrackingInterval = null;
 let settings = { ...DEFAULT_SETTINGS };
 let state = { ...DEFAULT_STATE };
 let dataFilePath = '';
+let lastBackupDate = '';
 
 function getUserDir() {
     return app.getPath('userData');
@@ -79,6 +80,33 @@ function ensureDataDir() {
 function getDataFilePath() {
     const dir = ensureDataDir();
     return path.join(dir, 'balance.json');
+}
+
+function getBackupDir() {
+    return path.join(getUserDir(), 'config_backups');
+}
+
+function maybeBackupDaily() {
+    try {
+        const srcPath = dataFilePath || getDataFilePath();
+        const today = getTodayDateString();
+        if (lastBackupDate === today) return;
+
+        const backupDir = getBackupDir();
+        try { fs.mkdirSync(backupDir, { recursive: true }); } catch { }
+        const destPath = path.join(backupDir, `balance-${today}.json`);
+        try {
+            fs.copyFileSync(srcPath, destPath, fs.constants.COPYFILE_EXCL);
+            lastBackupDate = today;
+        } catch (e) {
+            if (e && e.code === 'EEXIST') {
+                // Backup for today already exists; mark as done to avoid checks
+                lastBackupDate = today;
+            }
+        }
+    } catch (e) {
+        // Swallow errors to avoid impacting primary save flow
+    }
 }
 
 function loadData() {
@@ -96,6 +124,7 @@ function loadData() {
         } else {
             saveData();
         }
+        maybeBackupDaily();
     } catch (e) {
         console.error('Failed to load data:', e);
     }
@@ -107,6 +136,7 @@ function saveData() {
         dataFilePath = p;
         const payload = { settings, state };
         fs.writeFileSync(p, JSON.stringify(payload, null, 2), 'utf-8');
+        maybeBackupDaily();
     } catch (e) {
         console.error('Failed to save data:', e);
     }
@@ -641,6 +671,7 @@ ipcMain.handle('balance:save-settings', (_e, nextSettings) => {
         const newPath = path.join(newDir, 'balance.json');
         fs.writeFileSync(newPath, JSON.stringify({ settings, state }, null, 2), 'utf-8');
         dataFilePath = newPath;
+        maybeBackupDaily();
     } else {
         saveData();
     }

--- a/electron/main.js
+++ b/electron/main.js
@@ -124,7 +124,6 @@ function loadData() {
         } else {
             saveData();
         }
-        maybeBackupDaily();
     } catch (e) {
         console.error('Failed to load data:', e);
     }
@@ -671,7 +670,6 @@ ipcMain.handle('balance:save-settings', (_e, nextSettings) => {
         const newPath = path.join(newDir, 'balance.json');
         fs.writeFileSync(newPath, JSON.stringify({ settings, state }, null, 2), 'utf-8');
         dataFilePath = newPath;
-        maybeBackupDaily();
     } else {
         saveData();
     }


### PR DESCRIPTION
Add daily backups for `balance.json` to a `config_backups` folder in the user directory, ensuring only one backup per day with minimal disk operations.

---
Linear Issue: [BAL-48](https://linear.app/balance-jonah/issue/BAL-48/create-regular-backups-of-balancejson)

<a href="https://cursor.com/background-agent?bcId=bc-0a52e78d-91cd-4ac6-a375-59c6dac122d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0a52e78d-91cd-4ac6-a375-59c6dac122d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a once-per-day backup of `balance.json` to `config_backups`, triggered on save and guarded against duplicates.
> 
> - **Electron main**:
>   - **Daily backup system**:
>     - New `getBackupDir()` and `maybeBackupDaily()` create dated backups in `config_backups` (e.g., `balance-YYYY-MM-DD.json`).
>     - Invoked from `saveData()`; uses `COPYFILE_EXCL` and `lastBackupDate` to ensure one backup per day.
>     - Errors are swallowed to avoid impacting normal saves.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa8f4f246e2dd921183d03813fae2a9082966d0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->