### PR TITLE
Update color scheme on mission change

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -81,16 +81,44 @@
     $: pinkHasMore = computed?.outOfBalanceSign >= 0;
     $: withinRange = computed?.withinRange;
 
-    const crayon = {
-        bg: "#FFE2F5",
-        card: "#FDB3DB",
-        stroke: "#BF6091",
-        accent: "#E47ED1", // selected
-        mission1: "#e91e63",
-        mission2: "#108AB0",
-        breakColor: "#DDDDDD",
-        gray: "#8C8C8C",
-    };
+    function computeTheme(settings, state) {
+        const mission1Color = settings?.missions?.[0]?.color || "#e91e63";
+        const mission2Color = settings?.missions?.[1]?.color || "#2e7d32";
+        const gray = "#8C8C8C";
+
+        // Predefined palettes per mission for full scheme swap
+        const pinkTheme = {
+            bg: "#FFE2F5",
+            card: "#FDB3DB",
+            stroke: "#BF6091",
+            accent: "#E47ED1",
+        };
+        const greenTheme = {
+            bg: "#E0F2F1",
+            card: "#B2DFDB",
+            stroke: "#00695C",
+            accent: "#4DB6AC",
+        };
+        const neutralTheme = {
+            bg: "#F3F3F3",
+            card: "#E8E8E8",
+            stroke: "#9E9E9E",
+            accent: "#BDBDBD",
+        };
+
+        const idx = state?.currentMissionIndex ?? 0;
+        const base = idx === 0 ? pinkTheme : idx === 1 ? greenTheme : neutralTheme;
+
+        return {
+            ...base,
+            mission1: mission1Color,
+            mission2: mission2Color,
+            breakColor: "#DDDDDD",
+            gray,
+        };
+    }
+
+    $: crayon = computeTheme(settings, state);
 </script>
 
 <svelte:window
@@ -117,7 +145,7 @@
 
 <div
     class="root"
-    style="--bg:{crayon.bg}; --card:{crayon.card}; --stroke:{crayon.stroke}; --accent:{crayon.accent}"
+    style="--bg:{crayon.bg}; --card:{crayon.card}; --stroke:{crayon.stroke}; --accent:{crayon.accent}; --gray:{crayon.gray}"
 >
     <div class="row">
         <div class="title">
@@ -169,7 +197,7 @@
                 <button
                     class="btn seg {state.timer?.isBreak ? '' : 'selected'}"
                     on:click={startWork}
-                    style="background:#ffd2e1"
+                    style="background:var(--card)"
                     title="Start pomodoro"
                 >
                     🍅 Start Pomodoro
@@ -177,7 +205,7 @@
                 <button
                     class="btn seg {state.timer?.isBreak ? 'selected' : ''}"
                     on:click={startBreak}
-                    style="background:{crayon.breakColor}"
+                    style="background:var(--card)"
                     title="Start break"
                 >
                     🌿 Start Break


### PR DESCRIPTION
Implement mission-reactive theme switching using CSS variables to dynamically change the UI color scheme based on the current mission.

This change addresses BAL-49 by introducing a `computeTheme` function that derives a full color scheme based on the `currentMissionIndex`. The root element now uses these CSS variables, ensuring the entire UI's background, cards, borders, and accents shift automatically when the mission changes.

---
Linear Issue: [BAL-49](https://linear.app/balance-jonah/issue/BAL-49/make-it-so-the-whole-color-scheme-changes-when-you-change-missions)

<a href="https://cursor.com/background-agent?bcId=bc-3fa06f93-a3cc-4fe9-8ebd-1998c7f90470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3fa06f93-a3cc-4fe9-8ebd-1998c7f90470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

