### PR TITLE
Add discord call to action

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -692,6 +692,17 @@ ipcMain.handle('balance:quit', () => {
     app.quit();
 });
 
+// Open external URLs safely via main process
+ipcMain.handle('balance:open-external', (_e, url) => {
+    try {
+        if (typeof url === 'string' && /^https?:\/\//i.test(url)) {
+            shell.openExternal(url);
+        }
+    } catch (e) {
+        console.error('Failed to open external URL:', e);
+    }
+});
+
 app.whenReady().then(() => {
     // Hide dock icon on macOS
     if (process.platform === 'darwin') {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -13,6 +13,7 @@ contextBridge.exposeInMainWorld('balance', {
     open: () => ipcRenderer.invoke('balance:open'),
     openDataFolder: () => ipcRenderer.invoke('balance:open-data-folder'),
     quit: () => ipcRenderer.invoke('balance:quit'),
+    openExternal: (url) => ipcRenderer.invoke('balance:open-external', url),
     onState: (callback) => {
         const handler = (_event, message) => callback(message);
         ipcRenderer.on('balance:state', handler);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -140,9 +140,14 @@
                 {:else}[undefined]{/if}
             </span>
         </div>
-        <button class="btn" title="Options (o)" on:click={openOptions}
-            >⚙️</button
-        >
+        <div style="display:flex; gap:6px; align-items:center;">
+            <button class="btn" title="Join our Discord" on:click={() => window.balance.openExternal('https://discord.gg/assist')}
+                >🗨️ Join Discord</button
+            >
+            <button class="btn" title="Options (o)" on:click={openOptions}
+                >⚙️</button
+            >
+        </div>
     </div>
 
     {#if settings && state}


### PR DESCRIPTION
Add a "Join Discord" button to the app header to encourage users to join for support.

---
Linear Issue: [GRE-60](https://linear.app/greysound/issue/GRE-60/add-discord-ctas)

<a href="https://cursor.com/background-agent?bcId=bc-e4dd099c-555f-4ef6-aa69-2912bda0eb1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e4dd099c-555f-4ef6-aa69-2912bda0eb1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

