### PR TITLE
Add discord call to action

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -688,6 +688,16 @@ ipcMain.handle('balance:open-data-folder', () => {
     }
 });
 
+// Open Discord (configurable via env var DISCORD_INVITE_URL)
+ipcMain.handle('balance:open-discord', () => {
+    try {
+        const url = process.env.DISCORD_INVITE_URL || 'https://discord.gg/assist';
+        shell.openExternal(url);
+    } catch (e) {
+        console.error('Failed to open Discord URL:', e);
+    }
+});
+
 ipcMain.handle('balance:quit', () => {
     app.quit();
 });

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -13,6 +13,7 @@ contextBridge.exposeInMainWorld('balance', {
     open: () => ipcRenderer.invoke('balance:open'),
     openDataFolder: () => ipcRenderer.invoke('balance:open-data-folder'),
     quit: () => ipcRenderer.invoke('balance:quit'),
+    openDiscord: () => ipcRenderer.invoke('balance:open-discord'),
     onState: (callback) => {
         const handler = (_event, message) => callback(message);
         ipcRenderer.on('balance:state', handler);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -140,9 +140,12 @@
                 {:else}[undefined]{/if}
             </span>
         </div>
-        <button class="btn" title="Options (o)" on:click={openOptions}
-            >⚙️</button
-        >
+        <div class="header-actions">
+            <button class="btn discord" title="Join our Discord" on:click={() => api.openDiscord()}>💬 Join Discord</button>
+            <button class="btn" title="Options (o)" on:click={openOptions}
+                >⚙️</button
+            >
+        </div>
     </div>
 
     {#if settings && state}
@@ -389,6 +392,15 @@
         display: flex;
         align-items: center;
         justify-content: space-between;
+    }
+    .header-actions {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+    }
+    .btn.discord {
+        background: #5865F2; /* Discord brand color */
+        color: white;
     }
     .time-controls {
         display: flex;


### PR DESCRIPTION
Add a "Join Discord" button to the app header to encourage user engagement and support, as requested in GRE-60.

The button uses an Electron IPC mechanism to safely open an external Discord invite URL, which is configurable via the `DISCORD_INVITE_URL` environment variable.

---
Linear Issue: [GRE-60](https://linear.app/greysound/issue/GRE-60/add-discord-ctas)

<a href="https://cursor.com/background-agent?bcId=bc-aaa971a9-3aa8-4ed3-b366-96ac2e394699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aaa971a9-3aa8-4ed3-b366-96ac2e394699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

